### PR TITLE
Implement header trimming

### DIFF
--- a/src/io_fortran_lib/text_io_impl.f90
+++ b/src/io_fortran_lib/text_io_impl.f90
@@ -239,15 +239,15 @@ submodule (io_fortran_lib) text_io
     if ( header_present ) then
       select rank(x)
         rank(1)
-          cells(1,1)%s = header(1)
+          cells(1,1)%s = trim(header(1))
         rank(2)
           if ( size(header) == 1 ) then
             do j = 1, ncols
-              cells(1,j)%s = header(1)//str(j)
+              cells(1,j)%s = trim(header(1))//str(j)
             end do
           else
             do j = 1, ncols
-              cells(1,j)%s = header(j)
+              cells(1,j)%s = trim(header(j))
             end do
           end if
       end select
@@ -290,15 +290,15 @@ submodule (io_fortran_lib) text_io
     if ( header_present ) then
       select rank(x)
         rank(1)
-          cells(1,1)%s = header(1)
+          cells(1,1)%s = trim(header(1))
         rank(2)
           if ( size(header) == 1 ) then
             do j = 1, ncols
-              cells(1,j)%s = header(1)//str(j)
+              cells(1,j)%s = trim(header(1))//str(j)
             end do
           else
             do j = 1, ncols
-              cells(1,j)%s = header(j)
+              cells(1,j)%s = trim(header(j))
             end do
           end if
       end select
@@ -341,15 +341,15 @@ submodule (io_fortran_lib) text_io
     if ( header_present ) then
       select rank(x)
         rank(1)
-          cells(1,1)%s = header(1)
+          cells(1,1)%s = trim(header(1))
         rank(2)
           if ( size(header) == 1 ) then
             do j = 1, ncols
-              cells(1,j)%s = header(1)//str(j)
+              cells(1,j)%s = trim(header(1))//str(j)
             end do
           else
             do j = 1, ncols
-              cells(1,j)%s = header(j)
+              cells(1,j)%s = trim(header(j))
             end do
           end if
       end select
@@ -393,15 +393,15 @@ submodule (io_fortran_lib) text_io
     if ( header_present ) then
       select rank(x)
         rank(1)
-          cells(1,1)%s = header(1)
+          cells(1,1)%s = trim(header(1))
         rank(2)
           if ( size(header) == 1 ) then
             do j = 1, ncols
-              cells(1,j)%s = header(1)//str(j)
+              cells(1,j)%s = trim(header(1))//str(j)
             end do
           else
             do j = 1, ncols
-              cells(1,j)%s = header(j)
+              cells(1,j)%s = trim(header(j))
             end do
           end if
       end select
@@ -444,15 +444,15 @@ submodule (io_fortran_lib) text_io
     if ( header_present ) then
       select rank(x)
         rank(1)
-          cells(1,1)%s = header(1)
+          cells(1,1)%s = trim(header(1))
         rank(2)
           if ( size(header) == 1 ) then
             do j = 1, ncols
-              cells(1,j)%s = header(1)//str(j)
+              cells(1,j)%s = trim(header(1))//str(j)
             end do
           else
             do j = 1, ncols
-              cells(1,j)%s = header(j)
+              cells(1,j)%s = trim(header(j))
             end do
           end if
       end select
@@ -495,15 +495,15 @@ submodule (io_fortran_lib) text_io
     if ( header_present ) then
       select rank(x)
         rank(1)
-          cells(1,1)%s = header(1)
+          cells(1,1)%s = trim(header(1))
         rank(2)
           if ( size(header) == 1 ) then
             do j = 1, ncols
-              cells(1,j)%s = header(1)//str(j)
+              cells(1,j)%s = trim(header(1))//str(j)
             end do
           else
             do j = 1, ncols
-              cells(1,j)%s = header(j)
+              cells(1,j)%s = trim(header(j))
             end do
           end if
       end select
@@ -547,15 +547,15 @@ submodule (io_fortran_lib) text_io
     if ( header_present ) then
       select rank(x)
         rank(1)
-          cells(1,1)%s = header(1)
+          cells(1,1)%s = trim(header(1))
         rank(2)
           if ( size(header) == 1 ) then
             do j = 1, ncols
-              cells(1,j)%s = header(1)//str(j)
+              cells(1,j)%s = trim(header(1))//str(j)
             end do
           else
             do j = 1, ncols
-              cells(1,j)%s = header(j)
+              cells(1,j)%s = trim(header(j))
             end do
           end if
       end select
@@ -598,15 +598,15 @@ submodule (io_fortran_lib) text_io
     if ( header_present ) then
       select rank(x)
         rank(1)
-          cells(1,1)%s = header(1)
+          cells(1,1)%s = trim(header(1))
         rank(2)
           if ( size(header) == 1 ) then
             do j = 1, ncols
-              cells(1,j)%s = header(1)//str(j)
+              cells(1,j)%s = trim(header(1))//str(j)
             end do
           else
             do j = 1, ncols
-              cells(1,j)%s = header(j)
+              cells(1,j)%s = trim(header(j))
             end do
           end if
       end select
@@ -649,15 +649,15 @@ submodule (io_fortran_lib) text_io
     if ( header_present ) then
       select rank(x)
         rank(1)
-          cells(1,1)%s = header(1)
+          cells(1,1)%s = trim(header(1))
         rank(2)
           if ( size(header) == 1 ) then
             do j = 1, ncols
-              cells(1,j)%s = header(1)//str(j)
+              cells(1,j)%s = trim(header(1))//str(j)
             end do
           else
             do j = 1, ncols
-              cells(1,j)%s = header(j)
+              cells(1,j)%s = trim(header(j))
             end do
           end if
       end select
@@ -700,15 +700,15 @@ submodule (io_fortran_lib) text_io
     if ( header_present ) then
       select rank(x)
         rank(1)
-          cells(1,1)%s = header(1)
+          cells(1,1)%s = trim(header(1))
         rank(2)
           if ( size(header) == 1 ) then
             do j = 1, ncols
-              cells(1,j)%s = header(1)//str(j)
+              cells(1,j)%s = trim(header(1))//str(j)
             end do
           else
             do j = 1, ncols
-              cells(1,j)%s = header(j)
+              cells(1,j)%s = trim(header(j))
             end do
           end if
       end select


### PR DESCRIPTION
This commit allows for writing csv headers with non uniform number of characters. Before this commit, a header defined as:
```fortran
character(len=3) :: header(5)

header(1) = "a"
header(2) = "b"
header(3) = "aa"
header(4) = "bb"
header(5) = "ccc"

! ... more code...

call to_file(x=outdata, file="my_file.csv", fmt="f", header=header)
```
would result in a file with the following header:
```
a  ,b  ,aa ,bb ,ccc
```
while now the header in the csv file will be
```
a,b,aa,bb,ccc
```